### PR TITLE
chore: adds docker-file for easier local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 # PAYLOAD_SECRET=jawliejfilwajefSEANlawefawfewag349jwgo3gj4w
-# POSTGRES_URI=postgresql://postgres:password123@127.0.0.1:5432/next-payload-3
+# POSTGRES_URL=postgresql://postgres:password123@127.0.0.1:9001/next-payload-3
 # TMDB_API_KEY=<YOUR TMDB API KEY>
+# MONGODB_URL=mongodb://127.0.0.1:71072/payload-tmdb-movies

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ cp .env.example .env.development.local
 
 Create a local Postgres instance and change the connection string in .env.development.local to match.
 
+There is a [docker-compose](./docker-compose.yml) file in the root of the project that will start a Postgres instance for you. Just run `docker-compose up -d` to start it.
+
 Create a payload secret, perhaps using `openssl rand -base64 32` and set that value in the .env.development.local file.
 
 Get a [TMBD API key](https://www.themoviedb.org/settings/api) and add it to the .env.development.local file. You will need an account on TMDB. It's all free.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,5 @@ services:
   #   logging:
   #     driver: none
 
-  adminer:
-    image: adminer
-    restart: always
-    ports:
-      - 2345:5432
-      # - '71072:27017'
-
 volumes:
   data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    restart: always
+    ports:
+      - 2345:5432
+    volumes:
+      - data:/data/postgres
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_HOST_AUTH_METHOD: trust
+      POSTGRES_PASSWORD: password
+      POSTGRES_DB: payload-tmdb-movies
+
+  # mongo:
+  #   image: mongo:latest
+  #   ports:
+  #     - '71072:27017'
+  #   command:
+  #     - --storageEngine=wiredTiger
+  #   volumes:
+  #     - data:/data/db
+  #   logging:
+  #     driver: none
+
+  adminer:
+    image: adminer
+    restart: always
+    ports:
+      - 2345:5432
+      # - '71072:27017'
+
+volumes:
+  data:


### PR DESCRIPTION
Adds docker file for easier local development. Not everyone will have PG installed on their machine, figure this might be easier.

Also updates example env to match changed `process.env.POSTGRES_URL` variable used in the payload config. 